### PR TITLE
 NotificationTimeSpan + NotificationsCounts: add .descriptionString per CustomStringConvertibleCounts

### DIFF
--- a/NotificationManagementDemo.xcodeproj/project.pbxproj
+++ b/NotificationManagementDemo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		9D62D31225193B8900C1451A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA645CD8250FDB4B002FC84B /* NotificationManager.swift */; };
 		9D6B5B0A2527B5D80011B9E4 /* RudifaUtilPkg in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6B5B092527B5D80011B9E4 /* RudifaUtilPkg */; };
 		9D9792FE25220F0800A3B6C3 /* NotificationTimeSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9792FD25220F0800A3B6C3 /* NotificationTimeSpan.swift */; };
+		9DB3009A2545CF8800282E56 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA645CD8250FDB4B002FC84B /* NotificationManager.swift */; };
 		E110DF261DDF4D1300A01E9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E110DF251DDF4D1300A01E9A /* AppDelegate.swift */; };
 		E110DF281DDF4D1300A01E9A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E110DF271DDF4D1300A01E9A /* ViewController.swift */; };
 		E110DF2B1DDF4D1300A01E9A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E110DF291DDF4D1300A01E9A /* Main.storyboard */; };
@@ -233,6 +234,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9DB3009A2545CF8800282E56 /* NotificationManager.swift in Sources */,
 				9D06C4A725222CE80091BC17 /* NotificationTimeSpanTests.swift in Sources */,
 				9D06C4B325222CFF0091BC17 /* NotificationTimeSpan.swift in Sources */,
 			);

--- a/NotificationManagementDemo/App/AppDelegate.swift
+++ b/NotificationManagementDemo/App/AppDelegate.swift
@@ -10,40 +10,35 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         NotificationManager.shared.initializeAtAppStart()
-        //NotificationManager.shared.clearBadge()
+        // NotificationManager.shared.clearBadge()
         return true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
+    func applicationWillResignActive(_: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
         NotificationManager.shared.updateBadgeAndCounts()
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
+    func applicationDidEnterBackground(_: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(_ application: UIApplication) {
+    func applicationWillEnterForeground(_: UIApplication) {
         NotificationManager.shared.updateBadgeAndCounts()
         NotificationManager.shared.retrieveDiagnosticCounts()
     }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {
+    func applicationDidBecomeActive(_: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(_ application: UIApplication) {
+    func applicationWillTerminate(_: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }
-

--- a/NotificationManagementDemo/App/Base.lproj/Main.storyboard
+++ b/NotificationManagementDemo/App/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,7 +21,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="NGz-kE-vrI" userLabel="Stack View Controls">
-                                <rect key="frame" x="16" y="80" width="343" height="123.5"/>
+                                <rect key="frame" x="16" y="80" width="343" height="128"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="hE6-1A-zop" userLabel="Stack View Buttons">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
@@ -37,13 +37,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Counts Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0LE-Mc-9mK">
-                                        <rect key="frame" x="0.0" y="36" width="343" height="19.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                        <nil key="textColor"/>
+                                        <rect key="frame" x="0.0" y="36" width="343" height="24"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                        <color key="textColor" systemColor="systemPinkColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uNj-C2-iig" userLabel="Stack View Add Booking">
-                                        <rect key="frame" x="0.0" y="55.5" width="343" height="68"/>
+                                        <rect key="frame" x="0.0" y="60" width="343" height="68"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dAi-f4-r1V">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
@@ -75,7 +75,7 @@
                                 </subviews>
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6Vn-zp-WxW">
-                                <rect key="frame" x="16" y="203.5" width="343" height="455.5"/>
+                                <rect key="frame" x="16" y="208" width="343" height="451"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="1wh-M7-a8H">
@@ -114,6 +114,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/NotificationManagementDemo/NotificationManager.swift
+++ b/NotificationManagementDemo/NotificationManager.swift
@@ -183,20 +183,16 @@ extension NotificationManager {
     // Using DispatchGroup to execute two asynchronous operations and then handle the results
     func retrieveDiagnosticCounts() {
         let dispatchGroup = DispatchGroup()
-
         var diagnosticCounts = NotificationCounts(pending: -1, delivered: -1, current: -1)
 
         dispatchGroup.enter()
         center.getPendingNotificationRequests { pendingRequests in
+            self.printClassAndFunc(info: "@Pending  \(pendingRequests.count)")
             for request in pendingRequests {
                 self.printClassAndFunc(info: "@pendingRequests: \(NotificationTimeSpan(from: request.identifier)!)")
             }
-            self.printClassAndFunc(info: "@Pending  \(pendingRequests.count)")
-
-            DispatchQueue.main.async {
-                diagnosticCounts.pending = pendingRequests.count
-                dispatchGroup.leave()
-            }
+            diagnosticCounts.pending = pendingRequests.count
+            dispatchGroup.leave()
         }
 
         dispatchGroup.enter()
@@ -205,18 +201,16 @@ extension NotificationManager {
             for notification: UNNotification in deliveredNotifications {
                 self.printClassAndFunc(info: "@deliveredNotifications: \(NotificationTimeSpan(from: notification.request.identifier)!)")
             }
-            DispatchQueue.main.async {
-                diagnosticCounts.delivered = deliveredNotifications.count
-                diagnosticCounts.current = self.identifiersCurrent(in: deliveredNotifications).count
-                dispatchGroup.leave()
-            }
+            diagnosticCounts.delivered = deliveredNotifications.count
+            diagnosticCounts.current = self.identifiersCurrent(in: deliveredNotifications).count
+            dispatchGroup.leave()
         }
 
         dispatchGroup.notify(queue: .main) { [weak self] in
-            // do something with friends and events
-
             self?.printClassAndFunc(info: "@\(diagnosticCounts)")
-            self?.updateClientDiagnosticCounts?(diagnosticCounts)
+            DispatchQueue.main.async {
+                self?.updateClientDiagnosticCounts?(diagnosticCounts)
+            }
         }
     }
 }

--- a/NotificationManagementDemo/NotificationManager.swift
+++ b/NotificationManagementDemo/NotificationManager.swift
@@ -9,12 +9,17 @@
 import UIKit
 import UserNotifications
 
-struct NotificationCounts {
+struct NotificationCounts: CustomStringConvertible {
     var pending: Int
     var delivered: Int
     var current: Int
 
+    @available(*, unavailable, renamed: "description")
     var string: String {
+        return "pending: \(pending), delivered: \(delivered), current: \(current)"
+    }
+
+    var description: String {
         return "pending: \(pending), delivered: \(delivered), current: \(current)"
     }
 }
@@ -59,9 +64,10 @@ class NotificationManager: NSObject {
             return
         }
 
-        guard let identifier = NotificationTimeSpan(title: title, body: body, timeSpan: interval).string else {
-            return
-        }
+        let notificationTimeSpan = NotificationTimeSpan(title: title, body: body, timeSpan: interval)
+        printClassAndFunc(info: "@\(notificationTimeSpan)")
+
+        guard let identifier = notificationTimeSpan.jsonString else { return }
 
         // set content
         let content = UNMutableNotificationContent()
@@ -96,7 +102,7 @@ class NotificationManager: NSObject {
 
     /// Remove a pending notificaton
     /// - Parameter id: target notification id
-    func removeNotificationRequest(with id: String) {
+    func removePendingNotificationRequests(with id: String) {
         printClassAndFunc(info: id)
         // executes asynchronously, has no callback to report completion
         center.removePendingNotificationRequests(withIdentifiers: [id])
@@ -120,21 +126,22 @@ class NotificationManager: NSObject {
     }
 
     func updateBadgeAndCounts() {
-        UNUserNotificationCenter.current().getDeliveredNotifications { delivered in
+        UNUserNotificationCenter.current().getDeliveredNotifications { deliveredNotifications in
 
             // update badge count to the number of current notifications
 
-            let currentNotifications = delivered.filter { (NotificationTimeSpan(from: $0.request.identifier)?.isCurrent ?? false) }
+            let currentNotifications = deliveredNotifications.filter { (NotificationTimeSpan(from: $0.request.identifier)?.isCurrent ?? false) }
             DispatchQueue.main.async {
                 UIApplication.shared.applicationIconBadgeNumber = currentNotifications.count
             }
 
             // remove obsolete (not current) notifications
 
-            let identifiers = delivered.map({ $0.request.identifier })
+            let identifiers = deliveredNotifications.map({ $0.request.identifier })
             let identifiersNotCurrent = identifiers.filter({ !(NotificationTimeSpan(from: $0)?.isCurrent ?? true) })
             self.center.removeDeliveredNotifications(withIdentifiers: identifiersNotCurrent)
-            self.printClassAndFunc(info: "delivered: \(delivered.count) current: \(currentNotifications.count)")
+
+            self.printClassAndFunc(info: "@delivered: \(deliveredNotifications.count) current: \(currentNotifications.count)")
         }
     }
 
@@ -156,7 +163,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     // The method will be called on the delegate only if the application is in the foreground. If the method is not implemented or the handler is not called in a timely manner then the notification will not be presented. The application can choose to have the notification presented as a sound, badge, alert and/or in the notification list. This decision should be based on whether the information in the notification is otherwise visible to the user.
 
     internal func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        printClassAndFunc()
+        printClassAndFunc(info: "@")
         retrieveDiagnosticCounts()
         updateBadgeAndCounts()
         completionHandler([.alert, .badge, .sound])
@@ -182,9 +189,9 @@ extension NotificationManager {
         dispatchGroup.enter()
         center.getPendingNotificationRequests { pendingRequests in
             for request in pendingRequests {
-                print("  id: \(request.identifier)")
+                self.printClassAndFunc(info: "@pendingRequests: \(NotificationTimeSpan(from: request.identifier)!)")
             }
-            self.printClassAndFunc(info: "Pending  \(pendingRequests.count)")
+            self.printClassAndFunc(info: "@Pending  \(pendingRequests.count)")
 
             DispatchQueue.main.async {
                 diagnosticCounts.pending = pendingRequests.count
@@ -193,23 +200,23 @@ extension NotificationManager {
         }
 
         dispatchGroup.enter()
-        center.getDeliveredNotifications { notifications in
-            self.printClassAndFunc(info: "Delivered  \(notifications.count)")
-            for notification: UNNotification in notifications {
-                print("  id: \(notification.request.identifier)")
+        center.getDeliveredNotifications { deliveredNotifications in
+            self.printClassAndFunc(info: "@Delivered  \(deliveredNotifications.count)")
+            for notification: UNNotification in deliveredNotifications {
+                self.printClassAndFunc(info: "@deliveredNotifications: \(NotificationTimeSpan(from: notification.request.identifier)!)")
             }
             DispatchQueue.main.async {
-                diagnosticCounts.delivered = notifications.count
-                diagnosticCounts.current = self.identifiersCurrent(in: notifications).count
+                diagnosticCounts.delivered = deliveredNotifications.count
+                diagnosticCounts.current = self.identifiersCurrent(in: deliveredNotifications).count
                 dispatchGroup.leave()
             }
         }
 
         dispatchGroup.notify(queue: .main) { [weak self] in
             // do something with friends and events
-            self?.printClassAndFunc(info: diagnosticCounts.string)
+
+            self?.printClassAndFunc(info: "@\(diagnosticCounts)")
             self?.updateClientDiagnosticCounts?(diagnosticCounts)
         }
     }
 }
-

--- a/NotificationManagementDemo/Util/NotificationTimeSpan.swift
+++ b/NotificationManagementDemo/Util/NotificationTimeSpan.swift
@@ -9,6 +9,22 @@
 import Foundation
 import RudifaUtilPkg
 
+extension Date {
+    /// Return a dateTimeString with microsecond resolution
+    var ddMMyyyy_HHmmss_𝜇s: String {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond],
+                                       from: self)
+        let microSeconds = lrint(Double(comps.nanosecond!) / 1000) // Divide by 1000 and round
+
+        let formatted = String(format: "%04ld-%02ld-%02ld %02ld:%02ld:%02ld.%06ld",
+                               comps.year!, comps.month!, comps.day!,
+                               comps.hour!, comps.minute!, comps.second!,
+                               microSeconds)
+        return formatted
+    }
+}
+
 struct NotificationTimeSpan: Codable, Equatable {
     var title: String
     var message: String
@@ -36,12 +52,23 @@ extension NotificationTimeSpan {
         end = timeSpan.end
     }
 
-    init?(from string: String) {
-        guard let this = Self.decode(from: string) else { return nil }
+    init?(from jsonString: String) {
+        guard let this = Self.decode(from: jsonString) else { return nil }
         self = this
     }
 
+    @available(*, unavailable, renamed: "jsonString")
     var string: String? {
         return encode()
+    }
+
+    var jsonString: String? {
+        return encode()
+    }
+}
+
+extension NotificationTimeSpan: CustomStringConvertible {
+    var description: String {
+        return "title= \(title), message= \(message), start= \(start.ddMMyyyy_HHmmss_𝜇s), end= \(end.ddMMyyyy_HHmmss_𝜇s)"
     }
 }

--- a/NotificationManagementDemo/ViewController.swift
+++ b/NotificationManagementDemo/ViewController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2016 Steven Lipton. All rights reserved.
 //
 
-import UIKit
 import RudifaUtilPkg
+import UIKit
 
 struct Booking {
     var interval: DateInterval
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
         tableView.reloadData()
 
         let title = "SomeCalendar"
-        let body = "Your booking Starts now"
+        let body = "Your booking starts now"
         NotificationManager.shared.addNotification(title: title, body: body, for: booking.interval)
     }
 
@@ -79,7 +79,7 @@ class ViewController: UIViewController {
 
     func updateCountsLabel(counts: NotificationCounts) {
         DispatchQueue.main.async {
-            self.countsLabel.text = counts.string
+            self.countsLabel.text = counts.description
         }
     }
 }
@@ -109,7 +109,7 @@ extension ViewController: UITableViewDelegate {
             alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
                 let removedBooking = self.bookings.remove(at: indexPath.row)
                 self.tableView.reloadData()
-                NotificationManager.shared.removeNotificationRequest(with: removedBooking.id)
+                NotificationManager.shared.removePendingNotificationRequests(with: removedBooking.id)
             })
             alert.addAction(UIAlertAction(title: "Cancel", style: .default) { _ in print("Cancel") })
             present(alert, animated: true)

--- a/NotificationManagementDemoTests/NotificationTimeSpanTests.swift
+++ b/NotificationManagementDemoTests/NotificationTimeSpanTests.swift
@@ -14,15 +14,28 @@ class NotificationTimeSpanTests: XCTestCase {
     override func tearDownWithError() throws {}
 
     func test_NotificationTimeSpan() {
-        let calendar = Calendar.current
-        let refDate = calendar.date(from: DateComponents(calendar: calendar, year: 2020, month: 1, day: 28, hour: 14))!
-        let interval = DateInterval(start: refDate, duration: 7200)
-        let tsNotification = NotificationTimeSpan(title: "Title", message: "message", start: interval.start, end: interval.end)
-        let identifier = tsNotification.string!
-        XCTAssertEqual(identifier, #"{"message":"message","title":"Title","end":601916400,"start":601909200}"#)
+        // create a test DateInterval
+        let testDate = Date(timeIntervalSinceReferenceDate: 625_329_725.286_747)
+        let testInterval = DateInterval(start: testDate, duration: 7200)
+        XCTAssertEqual(testDate.ddMMyyyy_HHmmss_𝜇s, "2020-10-25 15:42:05.286747")
 
-        let tsNotification2 = NotificationTimeSpan.decode(from: identifier)
-        XCTAssertEqual(tsNotification, tsNotification2)
-        XCTAssertFalse(tsNotification.isCurrent)
+        // create a NotificationTimeSpan and a notification identifier
+        let testSpan = NotificationTimeSpan(title: "SomeResource", message: "booked", start: testInterval.start, end: testInterval.end)
+        XCTAssertEqual(testSpan.description, "title= SomeResource, message= booked, start= 2020-10-25 15:42:05.286747, end= 2020-10-25 17:42:05.286747")
+        XCTAssertEqual("\(testSpan)", "title= SomeResource, message= booked, start= 2020-10-25 15:42:05.286747, end= 2020-10-25 17:42:05.286747")
+
+        guard let testIdentifier = testSpan.jsonString else { XCTFail(); return }
+        XCTAssertEqual(testIdentifier, #"{"message":"booked","title":"SomeResource","end":625336925.28674698,"start":625329725.28674698}"#)
+
+        // recover a NotificationTimeSpan from the identifier and compare with the original
+        let testSpan2 = NotificationTimeSpan(from: testIdentifier)
+        XCTAssertEqual(testSpan, testSpan2)
+        // XCTAssertFalse(testSpan.isCurrent)
+    }
+
+    func test_NotificationCounts() {
+        let testCounts = NotificationCounts(pending: 1, delivered: 7, current: 2)
+        XCTAssertEqual(testCounts.description, "pending: 1, delivered: 7, current: 2")
+        XCTAssertEqual("\(testCounts)", "pending: 1, delivered: 7, current: 2")
     }
 }


### PR DESCRIPTION
@epajot **Please test these changes and integrate if OK**

Changes:
- rename `NotificationTimeSpan.string` to `.jsonString` for clarity, add description
- `NotificationTimeSpan` + `NotificationsCounts`: add `.descriptionString` per `CustomStringConvertible`

These do not modify the behavior of the demo.